### PR TITLE
Basic yk integration.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,48 @@
+#! /bin/sh
+
+set -e
+
+# Install rustup.
+export CARGO_HOME="`pwd`/.cargo"
+export RUSTUP_HOME="`pwd`/.rustup"
+export RUSTUP_INIT_SKIP_PATH_CHECK="yes"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+sh rustup.sh --default-host x86_64-unknown-linux-gnu \
+    --default-toolchain nightly \
+    --no-modify-path \
+    --profile minimal \
+    -y
+export PATH=${CARGO_HOME}/bin/:$PATH
+
+git clone -b yk/12.0-2021-04-15 https://github.com/vext01/llvm-project
+cd llvm-project
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
+    -DLLVM_INSTALL_UTILS=On \
+    -DCMAKE_BUILD_TYPE=release \
+    -DLLVM_ENABLE_ASSERTIONS=On \
+    -DLLVM_ENABLE_PROJECTS="lld;clang" \
+    ../llvm
+make -j `nproc` install
+export PATH=`pwd`/../inst/bin:${PATH}
+cd ../..
+
+git clone https://github.com/softdevteam/yk/
+cd yk && cargo build
+YK_INST_DIR=`pwd`/target/debug/
+cd ..
+
+# The CFLAGS are those suggest for clang in
+# https://devguide.python.org/setup/#clang.
+LDFLAGS="-L$YK_INST_DIR -Wl,-rpath=$YK_INST_DIR" CC=clang \
+  CPPFLAGS=-I`pwd`/yk/ykcapi \
+  CFLAGS="-Wno-unused-value -Wno-empty-body -Qunused-arguments" \
+  ./configure
+
+LDFLAGS="-L$YK_INST_DIR -Wl,-rpath=$YK_INST_DIR" \
+  CC=clang \
+  CPPFLAGS=-I`pwd`/yk/ykcapi \
+  CFLAGS="-Wno-unused-value -Wno-empty-body -Qunused-arguments" \
+  LD_LIBRARY_PATH=`pwd`/yk/target/release \
+  make -j `nproc` test

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -9,6 +9,7 @@
 #include "pymacconfig.h"
 
 #include <limits.h>
+#include <yk.h>
 
 #ifndef UCHAR_MAX
 #error "Something's broken.  UCHAR_MAX should be defined in limits.h."

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -62,6 +62,8 @@ struct PyCodeObject {
     _PyOpcache *co_opcache;
     int co_opcache_flag;  // used to determine when create a cache.
     unsigned char co_opcache_size;  // length of co_opcache.
+
+    YkLocation *co_yklocations;
 };
 
 /* Masks for co_flags above */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1575,6 +1575,8 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
     PyObject *consts;
     _PyOpcache *co_opcache;
 
+    MT *mt = yk_mt();
+
 #ifdef LLTRACE
     _Py_IDENTIFIER(__ltrace__);
 #endif
@@ -3840,6 +3842,9 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
             PREDICTED(JUMP_ABSOLUTE);
             JUMPTO(oparg);
             CHECK_EVAL_BREAKER();
+            // FIXME: the following line currently causes a panic as the mapper
+            // panics as soon as the hot threshold is exceeded.
+            // yk_control_point(mt, &co->co_yklocations[next_instr - first_instr]);
             DISPATCH();
         }
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+# The service providing the commit statuses to GitHub.
+status = ["buildbot/yk-buildbot-build-script-hw"]
+
+# Allow 60 minutes for build + tests
+timeout_sec = 3600
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true
+
+cut_body_after = ""

--- a/configure
+++ b/configure
@@ -17786,6 +17786,62 @@ $as_echo "no" >&6; }
 fi
 
 
+# yk integration
+ac_fn_c_check_header_mongrel "$LINENO" "yk.h" "ac_cv_header_yk_h" "$ac_includes_default"
+if test "x$ac_cv_header_yk_h" = xyes; then :
+
+else
+  as_fn_error $? "yk installation not found" "$LINENO" 5
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for yk_mt in -lykcapi" >&5
+$as_echo_n "checking for yk_mt in -lykcapi... " >&6; }
+if ${ac_cv_lib_ykcapi_yk_mt+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lykcapi  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char yk_mt ();
+int
+main ()
+{
+return yk_mt ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_ykcapi_yk_mt=yes
+else
+  ac_cv_lib_ykcapi_yk_mt=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ykcapi_yk_mt" >&5
+$as_echo "$ac_cv_lib_ykcapi_yk_mt" >&6; }
+if test "x$ac_cv_lib_ykcapi_yk_mt" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBYKCAPI 1
+_ACEOF
+
+  LIBS="-lykcapi $LIBS"
+
+else
+  as_fn_error $? "yk installation not found" "$LINENO" 5
+fi
+
 
 # generate output files
 ac_config_files="$ac_config_files Makefile.pre Misc/python.pc Misc/python-embed.pc Misc/python-config.sh"

--- a/configure.ac
+++ b/configure.ac
@@ -5933,6 +5933,10 @@ else
 fi
 AC_SUBST(TEST_MODULES)
 
+# yk integration
+AC_CHECK_HEADER([yk.h], [], [AC_MSG_ERROR([yk installation not found])])
+AC_CHECK_LIB([ykcapi], [yk_mt], [], [AC_MSG_ERROR([yk installation not found])])
+LINKFORSHARED="-lykcapi $LINKFORSHARED"
 
 # generate output files
 AC_CONFIG_FILES(Makefile.pre Misc/python.pc Misc/python-embed.pc Misc/python-config.sh)


### PR DESCRIPTION
Needs softdevteam/yk#337 merging first.

This builds CPython with basic yk support. As such yk doesn't do anything: at the time of this commit, the yk block mapper panics, so we can't even enable a control point (but this commit does add a commented-out control point as an example).

Mostly what this commit does is the minimal build integration of yk and CPython and minimal integration of yk Locations into CPython. Even this is not done efficiently: every bytecode is given a Location even though very few bytecodes will ever do anything to a Location. This is clearly wasteful of memory. We could probably do the same trick as the codeobject's co_opcache which has an intermediate map of locations (as an array of u8s i.e. a function can have at most 256 such caches) to save memory. Of course, that's an optimisation rather than anything fundamental, so we can leave that to a bit later.